### PR TITLE
Traffic light generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ endif ()
 
 # compiler specific flags
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -Wall -pedantic -Wextra -fPIC")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -pthread -Wall -pedantic -Wextra -fPIC")
 elseif (MSVC)
     # enabling /WX is not possible due to warnings in external headers
     # /Wall brings MSVC 2013 to complete halt

--- a/src/OSM2ODR.cpp
+++ b/src/OSM2ODR.cpp
@@ -68,12 +68,20 @@ namespace osm2odr {
     std::vector<std::string> OptionsArgs = {
       "--proj", settings.proj_string,
       "--geometry.remove", "--ramps.guess", "--edges.join", "--junctions.join", "--roundabouts.guess",
-      "--keep-edges.by-type",
-      "highway.motorway,highway.motorway_link,highway.trunk,highway.trunk_link,highway.primary,highway.primary_link,highway.secondary,highway.secondary_link,highway.tertiary,highway.tertiary_link,highway.unclassified,highway.residential",
-      "--tls.discard-loaded", "--tls.discard-simple", "--default.lanewidth",
+      "--default.lanewidth",
       std::to_string(settings.default_lane_width),
       "--osm-files", "TRUE", "--opendrive-output", "TRUE", // necessary for now to enable osm input and xodr output
     };
+    if (settings.osm_highways_types.size() == 0) {
+      WRITE_ERROR("No osm way types specified for importing.");
+      return "";
+    }
+    OptionsArgs.emplace_back("--keep-edges.by-type");
+    std::string edges_types = "";
+    for (std::string& osm_way_type : settings.osm_highways_types) {
+      edges_types += "highway." + osm_way_type + ",";
+    }
+    OptionsArgs.emplace_back(edges_types);
     if (settings.elevation_layer_height > 0) {
       OptionsArgs.emplace_back("--osm.layer-elevation");
       OptionsArgs.emplace_back(std::to_string(settings.elevation_layer_height));
@@ -92,6 +100,9 @@ namespace osm2odr {
     // OptionsCont::getOptions().clear();
     OptionsCont& oc = OptionsCont::getOptions();
     oc.input_osm_file = osm_file;
+    oc.generate_traffic_lights = settings.generate_traffic_lights;
+    oc.all_junctions_traffic_lights = settings.all_junctions_traffic_lights;
+    oc.tl_excluded_highways_types = settings.tl_excluded_highways_types;
 
     XMLSubSys::init();
     fillOptions();

--- a/src/OSM2ODR.h
+++ b/src/OSM2ODR.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace osm2odr {
 
@@ -18,6 +19,16 @@ namespace osm2odr {
     double elevation_layer_height = 0;
     std::string proj_string = "+proj=tmerc";
     bool center_map = true;
+    bool generate_traffic_lights = true;
+    bool all_junctions_traffic_lights = false;
+    std::vector<std::string> osm_highways_types = 
+        {"motorway", "motorway_link", "trunk", 
+         "trunk_link", "primary", "primary_link", 
+         "secondary", "secondary_link", "tertiary", 
+         "tertiary_link", "unclassified", "residential"};
+    std::vector<std::string> tl_excluded_highways_types = 
+        {"motorway_link", "primary_link", "secondary_link",
+         "tertiary_link"};
   };
 
   std::string ConvertOSMToOpenDRIVE(std::string osm_file, OSM2ODRSettings settings = OSM2ODRSettings());

--- a/src/netbuild/NBNode.h
+++ b/src/netbuild/NBNode.h
@@ -71,6 +71,7 @@ class NBNode : public Named, public Parameterised {
     friend class NBEdgePriorityComputer; // < computes priorities of edges per intersection
 
 public:
+    bool is_suitable_for_traffic_lights = true;
     /**
      * @class ApproachingDivider
      * @brief Computes lane-2-lane connections

--- a/src/utils/geom/Position.h
+++ b/src/utils/geom/Position.h
@@ -167,6 +167,14 @@ public:
         myY = myY / val;
     }
 
+    double lengthSquared() {
+        return myX * myX + myY * myY + myZ * myZ;
+    }
+
+    double length() {
+        return sqrt(lengthSquared());
+    }
+
     /// @brief output operator
     friend std::ostream& operator<<(std::ostream& os, const Position& p) {
         os << p.x() << "," << p.y();
@@ -189,6 +197,10 @@ public:
     /// @brief keep the direction but modify the length of the (location) vector to length * scalar
     Position operator*(double scalar) const {
         return Position(myX * scalar, myY * scalar, myZ * scalar);
+    }
+
+    Position operator/(double scalar) const {
+        return *(this)*(1.0/scalar);
     }
 
     /// @brief keep the direction but modify the length of the (location) vector to length + scalar

--- a/src/utils/options/OptionsCont.h
+++ b/src/utils/options/OptionsCont.h
@@ -670,6 +670,9 @@ public:
         return myFullName;
     }
 
+    bool generate_traffic_lights = true;
+    bool all_junctions_traffic_lights = false;
+    std::vector<std::string> tl_excluded_highways_types;
     std::string input_osm_file;
     std::string output_xodr_file;
 


### PR DESCRIPTION
This PR adds the following to the OSM to OpenDRIVE converter:
**c++14 support**
**Lane types to export**
You can define which types of lanes to convert to Opendrive from the OSM data. (e.g. only export "primary" roads)
**Traffic light generation**
Can be set to use OSM information or force every junction to generate traffic lights. It is possible to exclude specific roads when deciding to generate traffic lights.
An heuristic is used to place the traffic lights as they are not specified in OSM data.