### PR TITLE
Fixed edge roads

### DIFF
--- a/src/netimport/NIImporter_OpenStreetMap.cpp
+++ b/src/netimport/NIImporter_OpenStreetMap.cpp
@@ -1063,6 +1063,16 @@ NIImporter_OpenStreetMap::NodesHandler::~NodesHandler() = default;
 void
 NIImporter_OpenStreetMap::NodesHandler::myStartElement(int element, const SUMOSAXAttributes& attrs) {
     ++myHierarchyLevel;
+    if (element == SUMO_TAG_BOUNDS) {
+        bool ok = true;
+        minLon = attrs.get<double>(SUMO_ATTR_MINLON, myLastNodeID.c_str(), ok);
+        minLat = attrs.get<double>(SUMO_ATTR_MINLAT, myLastNodeID.c_str(), ok);
+        maxLon = attrs.get<double>(SUMO_ATTR_MAXLON, myLastNodeID.c_str(), ok);
+        maxLat = attrs.get<double>(SUMO_ATTR_MAXLAT, myLastNodeID.c_str(), ok);
+        if (!ok) {
+            return;
+        }
+    }
     if (element == SUMO_TAG_NODE) {
         bool ok = true;
         myLastNodeID = attrs.get<std::string>(SUMO_ATTR_ID, nullptr, ok);
@@ -1085,6 +1095,9 @@ NIImporter_OpenStreetMap::NodesHandler::myStartElement(int element, const SUMOSA
                 const double tlon = attrs.get<double>(SUMO_ATTR_LON, myLastNodeID.c_str(), ok);
                 const double tlat = attrs.get<double>(SUMO_ATTR_LAT, myLastNodeID.c_str(), ok);
                 if (!ok) {
+                    return;
+                }
+                if (tlon > maxLon || tlon < minLon || tlat > maxLat || tlat < minLat){
                     return;
                 }
                 myCurrentNode = new NIOSMNode(id, tlon, tlat);

--- a/src/netimport/NIImporter_OpenStreetMap.cpp
+++ b/src/netimport/NIImporter_OpenStreetMap.cpp
@@ -1065,10 +1065,10 @@ NIImporter_OpenStreetMap::NodesHandler::myStartElement(int element, const SUMOSA
     ++myHierarchyLevel;
     if (element == SUMO_TAG_BOUNDS) {
         bool ok = true;
-        minLon = attrs.get<double>(SUMO_ATTR_MINLON, myLastNodeID.c_str(), ok);
-        minLat = attrs.get<double>(SUMO_ATTR_MINLAT, myLastNodeID.c_str(), ok);
-        maxLon = attrs.get<double>(SUMO_ATTR_MAXLON, myLastNodeID.c_str(), ok);
-        maxLat = attrs.get<double>(SUMO_ATTR_MAXLAT, myLastNodeID.c_str(), ok);
+        minLon = attrs.get<double>(SUMO_ATTR_MINLON, myLastNodeID.c_str(), ok) + delta;
+        minLat = attrs.get<double>(SUMO_ATTR_MINLAT, myLastNodeID.c_str(), ok) + delta;
+        maxLon = attrs.get<double>(SUMO_ATTR_MAXLON, myLastNodeID.c_str(), ok) - delta;
+        maxLat = attrs.get<double>(SUMO_ATTR_MAXLAT, myLastNodeID.c_str(), ok) - delta;
         if (!ok) {
             return;
         }

--- a/src/netimport/NIImporter_OpenStreetMap.h
+++ b/src/netimport/NIImporter_OpenStreetMap.h
@@ -70,16 +70,16 @@ public:
 
 protected:
 
-/** @enum CycleWayType
- * @brief details on the kind of cycleway along this road
- */
-enum WayType {
-    WAY_NONE = 0,
-    WAY_FORWARD = 1,
-    WAY_BACKWARD = 2,
-    WAY_BOTH = WAY_FORWARD | WAY_BACKWARD,
-    WAY_UNKNOWN = 4
-};
+    /** @enum CycleWayType
+     * @brief details on the kind of cycleway along this road
+     */
+    enum WayType {
+        WAY_NONE = 0,
+        WAY_FORWARD = 1,
+        WAY_BACKWARD = 2,
+        WAY_BOTH = WAY_FORWARD | WAY_BACKWARD,
+        WAY_UNKNOWN = 4
+    };
 
     /** @brief An internal representation of an OSM-node
      */
@@ -391,12 +391,12 @@ protected:
     static void applyChangeProhibition(NBEdge* e, int changeProhibition);
     /// Applies lane use information from `nie` to `e`. Uses the member values
     /// `myLaneAllowedForward`, `myLaneDisallowedForward` and `myLaneDesignatedForward`
-    /// or the respective backward values to determine the ultimate lane uses. 
+    /// or the respective backward values to determine the ultimate lane uses.
     /// When a value of `e->myLaneDesignatedForward/Backward` is `true`, all permissions for the corresponding
     /// lane will be deleted before adding permissions from `e->myLaneAllowedForward/Backward`.
-    /// SVCs from `e->myLaneAllowedForward/Backward` will be added to the existing permissions (for each lane). 
+    /// SVCs from `e->myLaneAllowedForward/Backward` will be added to the existing permissions (for each lane).
     /// SVCs from `e->myLaneDisallowedForward/Backward` will be subtracted from the existing permissions.
-    /// @brief Applies lane use information from `nie` to `e`. 
+    /// @brief Applies lane use information from `nie` to `e`.
     /// @param e The NBEdge that the new information will be written to.
     /// @param nie Ths Edge that the information comes from.
     void applyLaneUse(NBEdge* e, NIImporter_OpenStreetMap::Edge* nie, const bool forward);

--- a/src/netimport/NIImporter_OpenStreetMap.h
+++ b/src/netimport/NIImporter_OpenStreetMap.h
@@ -485,6 +485,7 @@ protected:
         double minLat;
         double maxLon;
         double maxLat;
+        double delta = 0.002;
 
         /// @brief the options
         const OptionsCont& myOptionsCont;

--- a/src/netimport/NIImporter_OpenStreetMap.h
+++ b/src/netimport/NIImporter_OpenStreetMap.h
@@ -70,16 +70,16 @@ public:
 
 protected:
 
-    /** @enum CycleWayType
-     * @brief details on the kind of cycleway along this road
-     */
-    enum WayType {
-        WAY_NONE = 0,
-        WAY_FORWARD = 1,
-        WAY_BACKWARD = 2,
-        WAY_BOTH = WAY_FORWARD | WAY_BACKWARD,
-        WAY_UNKNOWN = 4
-    };
+/** @enum CycleWayType
+ * @brief details on the kind of cycleway along this road
+ */
+enum WayType {
+    WAY_NONE = 0,
+    WAY_FORWARD = 1,
+    WAY_BACKWARD = 2,
+    WAY_BOTH = WAY_FORWARD | WAY_BACKWARD,
+    WAY_UNKNOWN = 4
+};
 
     /** @brief An internal representation of an OSM-node
      */
@@ -391,12 +391,12 @@ protected:
     static void applyChangeProhibition(NBEdge* e, int changeProhibition);
     /// Applies lane use information from `nie` to `e`. Uses the member values
     /// `myLaneAllowedForward`, `myLaneDisallowedForward` and `myLaneDesignatedForward`
-    /// or the respective backward values to determine the ultimate lane uses.
+    /// or the respective backward values to determine the ultimate lane uses. 
     /// When a value of `e->myLaneDesignatedForward/Backward` is `true`, all permissions for the corresponding
     /// lane will be deleted before adding permissions from `e->myLaneAllowedForward/Backward`.
-    /// SVCs from `e->myLaneAllowedForward/Backward` will be added to the existing permissions (for each lane).
+    /// SVCs from `e->myLaneAllowedForward/Backward` will be added to the existing permissions (for each lane). 
     /// SVCs from `e->myLaneDisallowedForward/Backward` will be subtracted from the existing permissions.
-    /// @brief Applies lane use information from `nie` to `e`.
+    /// @brief Applies lane use information from `nie` to `e`. 
     /// @param e The NBEdge that the new information will be written to.
     /// @param nie Ths Edge that the information comes from.
     void applyLaneUse(NBEdge* e, NIImporter_OpenStreetMap::Edge* nie, const bool forward);
@@ -479,6 +479,12 @@ protected:
 
         /// @brief number of diplicate nodes
         int myDuplicateNodes;
+
+        /// Minimum and maximum bounds
+        double minLon;
+        double minLat;
+        double maxLon;
+        double maxLat;
 
         /// @brief the options
         const OptionsCont& myOptionsCont;

--- a/src/utils/xml/SUMOXMLDefinitions.cpp
+++ b/src/utils/xml/SUMOXMLDefinitions.cpp
@@ -145,6 +145,7 @@ SequentialStringBijection::Entry SUMOXMLDefinitions::tags[] = {
     { "conflict",                               SUMO_TAG_CONFLICT },
     { "prohibition",                            SUMO_TAG_PROHIBITION },
     { "split",                                  SUMO_TAG_SPLIT },
+    { "bounds",                                 SUMO_TAG_BOUNDS },
     { "node",                                   SUMO_TAG_NODE },
     { "type",                                   SUMO_TAG_TYPE },
     { "laneType",                               SUMO_TAG_LANETYPE },
@@ -1245,6 +1246,10 @@ SequentialStringBijection::Entry SUMOXMLDefinitions::attrs[] = {
     { "aggregate",              SUMO_ATTR_AGGREGATE },
     { "numEdges",               SUMO_ATTR_NUMEDGES },
 
+    { "minlon",                 SUMO_ATTR_MINLON },
+    { "minlat",                 SUMO_ATTR_MINLAT },
+    { "maxlon",                 SUMO_ATTR_MAXLON },
+    { "maxlat",                 SUMO_ATTR_MAXLAT },
     { "lon",                    SUMO_ATTR_LON },
     { "lat",                    SUMO_ATTR_LAT },
     { "action",                 SUMO_ATTR_ACTION },

--- a/src/utils/xml/SUMOXMLDefinitions.h
+++ b/src/utils/xml/SUMOXMLDefinitions.h
@@ -253,6 +253,8 @@ enum SumoXMLTag {
     /// @brief split something
     SUMO_TAG_SPLIT,
     /// @brief alternative definition for junction
+    SUMO_TAG_BOUNDS,
+    /// @brief alternative definition for junction
     SUMO_TAG_NODE,
     /// @brief type (edge)
     SUMO_TAG_TYPE,
@@ -1132,7 +1134,7 @@ enum SumoXMLAttr {
     /// @brief Stopping threshold
     SUMO_ATTR_STOPPINGTHRESHOLD,
     /// @}
-
+    
     /// @name tripinfo output attributes
     /// @{
     SUMO_ATTR_WAITINGCOUNT,
@@ -1625,6 +1627,10 @@ enum SumoXMLAttr {
     SUMO_ATTR_AGGREGATE,
     SUMO_ATTR_NUMEDGES,
 
+    SUMO_ATTR_MINLON,
+    SUMO_ATTR_MINLAT,
+    SUMO_ATTR_MAXLON,
+    SUMO_ATTR_MAXLAT,
     SUMO_ATTR_LON,
     SUMO_ATTR_LAT,
     SUMO_ATTR_ACTION,

--- a/src/utils/xml/SUMOXMLDefinitions.h
+++ b/src/utils/xml/SUMOXMLDefinitions.h
@@ -252,7 +252,7 @@ enum SumoXMLTag {
     SUMO_TAG_PROHIBITION,
     /// @brief split something
     SUMO_TAG_SPLIT,
-    /// @brief alternative definition for junction
+    /// @brief Latitude and longitude bounds
     SUMO_TAG_BOUNDS,
     /// @brief alternative definition for junction
     SUMO_TAG_NODE,
@@ -1134,7 +1134,7 @@ enum SumoXMLAttr {
     /// @brief Stopping threshold
     SUMO_ATTR_STOPPINGTHRESHOLD,
     /// @}
-    
+
     /// @name tripinfo output attributes
     /// @{
     SUMO_ATTR_WAITINGCOUNT,


### PR DESCRIPTION
Added the OSM bounds onto the parser. This filters the parts of the roads that are out of bounds. This was causing two issues. 

The most obvious one is the creation of roads outside of the map bounds.

The other one is the opposite. In order to know whether a road should be generated in CARLA, the center location is used. Without the bounds, the center could be located outside of the map, removing the whole road, even the part that was inside of the map.