### PR TITLE
Fixing Crash when Node is invalid

### DIFF
--- a/src/netimport/NIImporter_OpenStreetMap.cpp
+++ b/src/netimport/NIImporter_OpenStreetMap.cpp
@@ -332,7 +332,7 @@ NIImporter_OpenStreetMap::load(const OptionsCont& oc, NBNetBuilder& nb) {
 
         for (auto item : nodeUsage) {
             NIOSMNode* osmNode = myOSMNodes.find(item.first)->second;
-            if (osmNode->pedestrianCrossing) {
+            if (osmNode->pedestrianCrossing && osmNode->node != nullptr) {
                 NBNode* n = osmNode->node;
                 EdgeVector incomingEdges = n->getIncomingEdges();
                 EdgeVector outgoingEdges = n->getOutgoingEdges();


### PR DESCRIPTION
Fixes a crash when generating certain maps.

Tested on:
Windows 11 and Ubuntu 22

NOTE: This might break future implementations of pedestrian crossings for generation in Digital Twins. Since this is still not supported, it's just a note for now.